### PR TITLE
Fixes #10 Include Network Explorer Links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -258,9 +258,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.4.4.tgz",
-      "integrity": "sha512-a6222b7Dl6fIlMgzVl7e+NiRoLiZFbpcwvBH2Oli56Bn7W4/3Ld+86hK4ffPn5rx2DlDidmIcvIJiOQXyhv9gA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.4.5.tgz",
+      "integrity": "sha512-A6cOzSu7dqXZ7rzvh/9JZf+Jg/MOpLEMP0IdT8pT8hrWJZ6TB4ydN/MRuqOtAugInJe/VQ9F8BPricUpYZSaZA==",
       "dependencies": {
         "@grpc/proto-loader": "^0.6.4",
         "@types/node": ">=12.12.47"
@@ -694,9 +694,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.13.tgz",
-      "integrity": "sha512-eUXZzHLHoZqj1frtUetNkUetYoJ6X55UmrVnFD4DMhVeAmwLjniZhtBmsRiemQh4uq4G3vUra/Ws/hs9vEvL3Q=="
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.0.tgz",
+      "integrity": "sha512-eMhwJXc931Ihh4tkU+Y7GiLzT/y/DBNpNtr4yU9O2w3SYBsr9NaOPhQlLKRmoWtI54uNwuo0IOUFQjVOTZYRvw=="
     },
     "node_modules/@types/plist": {
       "version": "3.0.2",
@@ -1972,9 +1972,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-15.3.3.tgz",
-      "integrity": "sha512-tr4UaMosN6+s8vSbx6OxqRXDTTCBjjJkmDMv0b0sg8f+cRFQeY0u7xYbULpXS4B1+hHJmdh7Nz40Qpv0bJXa6w==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-15.3.4.tgz",
+      "integrity": "sha512-GLTE+UEKw1pJehkgpLgXtsHhYqSPp6skSNY1bxnY3dDYBrsPlP3nTEO9YQY2p4eHk+uxFVTXOVy5afcu9fIZ9A==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2177,9 +2177,9 @@
       }
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "14.18.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
-      "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ==",
+      "version": "14.18.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.1.tgz",
+      "integrity": "sha512-fTFWOFrgAkj737w1o0HLTIgisgYHnsZfeiqhG1Ltrf/iJjudEbUwetQAsfrtVE49JGwvpEzQR+EbMkIqG4227g==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -4626,9 +4626,9 @@
       }
     },
     "node_modules/svelte-check": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.2.10.tgz",
-      "integrity": "sha512-UVLd/N7hUIG2v6dytofsw8MxYn2iS2hpNSglsGz9Z9b8ZfbJ5jayl4Mm1SXhNwiFs5aklG90zSBJtd7NTK8dTg==",
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.2.11.tgz",
+      "integrity": "sha512-clotPGGZPj3LuS9qP1lk+Wwnsj+js42ehCPmHk+qtyaQh/dU95e0qkpPmtmOMYHN6My5Y75XqeN1QNLj5V5gwA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -4658,9 +4658,9 @@
       }
     },
     "node_modules/svelte-preprocess": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.0.tgz",
-      "integrity": "sha512-uZgGyC4SwkFoby2ceiMgGYs4qHYGz2fT06cAsHO8FHdDbvj1dKQyQ/fD9OB0KLymVv0fmzuJo/On7Kv7AeVhWA==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.1.tgz",
+      "integrity": "sha512-NSNloaylf+o9UeyUR2KvpdxrAyMdHl3U7rMnoP06/sG0iwJvlUM4TpMno13RaNqovh4AAoGsx1jeYcIyuGUXMw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -5517,9 +5517,9 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.4.4.tgz",
-      "integrity": "sha512-a6222b7Dl6fIlMgzVl7e+NiRoLiZFbpcwvBH2Oli56Bn7W4/3Ld+86hK4ffPn5rx2DlDidmIcvIJiOQXyhv9gA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.4.5.tgz",
+      "integrity": "sha512-A6cOzSu7dqXZ7rzvh/9JZf+Jg/MOpLEMP0IdT8pT8hrWJZ6TB4ydN/MRuqOtAugInJe/VQ9F8BPricUpYZSaZA==",
       "requires": {
         "@grpc/proto-loader": "^0.6.4",
         "@types/node": ">=12.12.47"
@@ -5872,9 +5872,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.13.tgz",
-      "integrity": "sha512-eUXZzHLHoZqj1frtUetNkUetYoJ6X55UmrVnFD4DMhVeAmwLjniZhtBmsRiemQh4uq4G3vUra/Ws/hs9vEvL3Q=="
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.0.tgz",
+      "integrity": "sha512-eMhwJXc931Ihh4tkU+Y7GiLzT/y/DBNpNtr4yU9O2w3SYBsr9NaOPhQlLKRmoWtI54uNwuo0IOUFQjVOTZYRvw=="
     },
     "@types/plist": {
       "version": "3.0.2",
@@ -6865,9 +6865,9 @@
       }
     },
     "electron": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-15.3.3.tgz",
-      "integrity": "sha512-tr4UaMosN6+s8vSbx6OxqRXDTTCBjjJkmDMv0b0sg8f+cRFQeY0u7xYbULpXS4B1+hHJmdh7Nz40Qpv0bJXa6w==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-15.3.4.tgz",
+      "integrity": "sha512-GLTE+UEKw1pJehkgpLgXtsHhYqSPp6skSNY1bxnY3dDYBrsPlP3nTEO9YQY2p4eHk+uxFVTXOVy5afcu9fIZ9A==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.13.0",
@@ -6876,9 +6876,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
-          "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ==",
+          "version": "14.18.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.1.tgz",
+          "integrity": "sha512-fTFWOFrgAkj737w1o0HLTIgisgYHnsZfeiqhG1Ltrf/iJjudEbUwetQAsfrtVE49JGwvpEzQR+EbMkIqG4227g==",
           "dev": true
         }
       }
@@ -8896,9 +8896,9 @@
       "dev": true
     },
     "svelte-check": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.2.10.tgz",
-      "integrity": "sha512-UVLd/N7hUIG2v6dytofsw8MxYn2iS2hpNSglsGz9Z9b8ZfbJ5jayl4Mm1SXhNwiFs5aklG90zSBJtd7NTK8dTg==",
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.2.11.tgz",
+      "integrity": "sha512-clotPGGZPj3LuS9qP1lk+Wwnsj+js42ehCPmHk+qtyaQh/dU95e0qkpPmtmOMYHN6My5Y75XqeN1QNLj5V5gwA==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
@@ -8921,9 +8921,9 @@
       }
     },
     "svelte-preprocess": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.0.tgz",
-      "integrity": "sha512-uZgGyC4SwkFoby2ceiMgGYs4qHYGz2fT06cAsHO8FHdDbvj1dKQyQ/fD9OB0KLymVv0fmzuJo/On7Kv7AeVhWA==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.1.tgz",
+      "integrity": "sha512-NSNloaylf+o9UeyUR2KvpdxrAyMdHl3U7rMnoP06/sG0iwJvlUM4TpMno13RaNqovh4AAoGsx1jeYcIyuGUXMw==",
       "dev": true,
       "requires": {
         "@types/pug": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creators-galaxy/token-distribution-tool",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Creator's Galaxy Token Distribution Tool",
   "author": "Calaxy, Inc.",
   "license": "MIT",

--- a/src/app/components/TransfersTable.svelte
+++ b/src/app/components/TransfersTable.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+import { invoke } from "../common/ipc";
+
+
   	export let transfers: { account:string, amount: string }[];
     export let decimals: number = 0;  
 
@@ -14,15 +17,33 @@
         };
     });    
 
+    // this is a little more complex than otherwise
+    // would usually create, we don't have to have 
+    // click handler registrations for each row in 
+    // the table, we wrap it up to one handler so the
+    // dom can render with less complication.
+    async function handleClick(evt) {
+        for(let element = evt.target; element; element = element.parentElement) {
+            const index = element.dataset.account;
+            if(index) {
+                evt.preventDefault();
+                const transfer = transfers[index-1];
+                if(transfer) {
+                    await invoke('open-address-explorer',transfer.account);
+                }
+            }
+        }
+    }
+
 </script>
-<div class="container">
+<div class="container" on:click={handleClick}>
     <div class="headers">
         <div>Account</div>
         <div>Amount</div>
     </div>
     <div class="data">
-        {#each data as { shard, realm, num, whole, fraction }}
-        <div class="account"><span class="shard">{shard}.</span><span class="realm">{realm}.</span><span class="num">{num}</span></div>
+        {#each data as { shard, realm, num, whole, fraction }, index}
+        <div class="account" data-account={index+1}><span class="shard">{shard}.</span><span class="realm">{realm}.</span><span class="num">{num}</span></div>
         <div class="amount"><span class="whole">{whole}</span><span class="fraction">.{fraction}</span></div>
         {/each}
     </div>
@@ -77,6 +98,15 @@
     {
         padding: 0.25rem 1.5rem;
         border-bottom: 1px solid var(--tcg-dark-gray2);
+    }
+    div.data > div.account
+    {
+        cursor: pointer;
+    }
+    div.data > div.account:hover
+    {
+        color: var(--tcg-green);
+        text-decoration: underline;
     }
     div.data > div.amount
     {

--- a/src/process/distribution.ts
+++ b/src/process/distribution.ts
@@ -310,6 +310,16 @@ export function getTreasuryInformation(): Promise<TreasuryInfo> {
 	});
 }
 /**
+ * Internal helper function returning the currently selected
+ * network ID.  This is utilized by user interface components
+ * generating urls to the proper DLT explorers such as dragonglass.
+ *
+ * @returns the currently selected network ID
+ */
+export function getNetworkId(): NetworkId {
+	return networkId;
+}
+/**
  * Receives the treasury and crypto account information entered by the user.  Will not
  * throw an exception but will add any validation errors to the `tokenInfoErrors` array.
  *

--- a/src/process/ipc.ts
+++ b/src/process/ipc.ts
@@ -11,7 +11,14 @@ import {
 	setTreasuryInformation,
 } from './distribution';
 import { validatePrivateKey } from './keys';
-import { getAppVersion, queryUserForCsvFile, queryUserForOutputFile } from './ui';
+import {
+	getAppVersion,
+	openAddressExplorer,
+	openScheduledTransactionExplorer,
+	openTransactionExplorer,
+	queryUserForCsvFile,
+	queryUserForOutputFile,
+} from './ui';
 /**
  * The registry of supported/whitelisted methods executing in the
  * node process thread that can be invoked from the Electron User
@@ -30,6 +37,9 @@ const methods: { [key: string]: (...args: any[]) => Promise<any> } = {
 	'query-user-for-output-file': queryUserForOutputFile,
 	'save-results-output-file': saveDistributionResultsFile,
 	'get-app-version': getAppVersion,
+	'open-address-explorer': openAddressExplorer,
+	'open-transaction-explorer': openTransactionExplorer,
+	'open-scheduled-transaction-explorer': openScheduledTransactionExplorer,
 };
 /**
  * The single IPC entry point used by the Electron User Interface

--- a/src/process/ui.ts
+++ b/src/process/ui.ts
@@ -1,5 +1,9 @@
-import { app, BrowserWindow, dialog } from 'electron';
+import * as https from 'https';
+import { AccountId, TransactionId } from '@hashgraph/sdk';
+import electron, { app, BrowserWindow, dialog } from 'electron';
 import { homedir } from 'os';
+import { NetworkId } from '../common/primitives';
+import { getNetworkId } from './distribution';
 /**
  * Displays a native file open dialog box for “csv” files to the user.
  * If the user selects a file (that must already exist) the method returns
@@ -49,4 +53,115 @@ export async function queryUserForOutputFile(): Promise<string> {
  */
 export async function getAppVersion(): Promise<string> {
 	return Promise.resolve(app.getVersion());
+}
+/**
+ * Launches the operating system's default browser with
+ * a URL crafted to display information for the targeted
+ * account or schedule ID.   Current Implementation points
+ * to Kabuto Hashgraph Explorer V.2.
+ *
+ * @param accountId string representation of the account or
+ * schedule ID to explore.
+ */
+export async function openAddressExplorer(accountId: string) {
+	try {
+		const account = AccountId.fromString(accountId);
+		const url =
+			getNetworkId() === NetworkId.Test
+				? `https://v2.explorer.kabuto.sh/id/${account.toString()}?network=testnet`
+				: `https://v2.explorer.kabuto.sh/id/${account.toString()}`;
+		electron.shell.openExternal(url);
+	} catch (err) {
+		throw new Error('Invalid Account Id');
+	}
+}
+/**
+ * Launches the operating system's default browser with a URL crafted
+ * to display information for the identified transaction.  Currenetly only
+ * works with non-scheduled and non-nonce transaction IDs.  Implementation
+ * points to Kabuto Hashgraph Explorer V.2.
+ *
+ * @param transactionId the transaction id in the standard id@sec.nano format.
+ */
+export async function openTransactionExplorer(transactionId: string) {
+	try {
+		const transaction = TransactionId.fromString(transactionId);
+		const url =
+			getNetworkId() === NetworkId.Test
+				? `https://v2.explorer.kabuto.sh/transaction/${transaction.toString()}?network=testnet`
+				: `https://v2.explorer.kabuto.sh/transaction/${transaction.toString()}`;
+		electron.shell.openExternal(url);
+	} catch (err) {
+		throw new Error('Invalid Account Id');
+	}
+}
+/**
+ * Attempts to launch the operating system's default browser with a URL crafted
+ * to display information for the transaction that was executed by the given
+ * schedule.  If the scheduled transaction has not yet been executed, the URL
+ * will point to information for the scheduled transaction (by ID) itself.
+ * Current implemenation points to Kabuto Hashgraph Explorer V.2.
+ *
+ * @param scheduleId the schedule ID to attempt to find the executed scheduled
+ * transaction.
+ */
+export async function openScheduledTransactionExplorer(scheduleId: string) {
+	try {
+		const schedule = AccountId.fromString(scheduleId);
+		const scheduleIdAsString = schedule.toString();
+		const url =
+			getNetworkId() === NetworkId.Test
+				? `https://v2.api.testnet.kabuto.sh/transaction?filter[entityId]=${scheduleIdAsString}`
+				: `https://v2.api.kabuto.sh/transaction?filter[entityId]=${scheduleIdAsString}`;
+		const transactions = await httpsGetJson(url);
+		if (transactions) {
+			const txHash = transactions.find((tx) => tx['viaScheduleId'] === scheduleIdAsString)?.hash;
+			if (txHash) {
+				const txUrl =
+					getNetworkId() === NetworkId.Test
+						? `https://v2.explorer.kabuto.sh/transaction/${txHash}?network=testnet`
+						: `https://v2.explorer.kabuto.sh/transaction/${txHash}`;
+				electron.shell.openExternal(txUrl);
+				return;
+			}
+		}
+		// If not executed, navigate to the schedule page instead.
+		await openAddressExplorer(scheduleIdAsString);
+	} catch (err) {
+		throw new Error('Invalid Account Id');
+	}
+}
+/**
+ * Helper function to fetch a JSON object from the
+ * Kabuto Exploer API.  It assumes the returned JSON
+ * payload has a property "data".  If the property is
+ * found, it is returned, otherwise null is returned
+ * (or an error if the request failes due to other reasons)
+ *
+ * @param url url to fetch from the API.
+ *
+ * @returns an object literal parsed from the JSON
+ * payload returned from the server if found, otherwise
+ * the value `null`.
+ */
+function httpsGetJson(url: string): Promise<any> {
+	return new Promise((resolve, reject) => {
+		https
+			.get(url, (resp) => {
+				let data = '';
+				resp.on('data', (chunk) => {
+					data += chunk;
+				});
+				resp.on('end', () => {
+					try {
+						var rawData = JSON.parse(data);
+						resolve(rawData.data ? rawData.data : null);
+					} catch (err) {
+						reject(err);
+					}
+					resolve(JSON.parse(data));
+				});
+			})
+			.on('error', reject);
+	});
 }


### PR DESCRIPTION
Updated the user interface when listing
accounts, schedules and transaction IDs to be
links that will launch the operating system’s
default browser navigating to the Kabuto
Explorer V.2 displaying the details for the
target item.

Note there is one potential issue on the first
page, if the accounts listed just after the initial
CSV import, the application has no context to
know which network to query and assumes
mainnet.  If the accounts are for testnet,
invalid results may be returned.