### PR TITLE
Remove status from success message

### DIFF
--- a/src/process/distribution.ts
+++ b/src/process/distribution.ts
@@ -856,7 +856,7 @@ export async function executeDistributionPlan(progress: (any) => void): Promise<
 					const status = payment.confirmationResult.response?.status || (payment.confirmationResult.error as StatusError)?.status;
 					switch (status) {
 						case Status.Success:
-							return 'Status: Distribution Completed';
+							return 'Distribution Completed';
 						case undefined:
 						case null:
 						case Status.ReceiptNotFound:
@@ -963,7 +963,7 @@ export async function executeDistributionPlan(progress: (any) => void): Promise<
 				Promise.resolve(new TryGetTransactionReceiptQuery().setTransactionId(scheduledTxId).setNodeAccountIds(nodeIds)),
 			));
 			if (response) {
-				payment.status = response.status === Status.Success ? 'Status: Distribution Completed' : `Status: ${response.status.toString()}`;
+				payment.status = response.status === Status.Success ? 'Distribution Completed' : `Status: ${response.status.toString()}`;
 				summaryWorker.postMessage({ payment: castDistributionInfo(payment) });
 			} else {
 				nextRound.push(payment);

--- a/test/integration/process/distribution.scenario-auto-associated-distribution-scenario.spec.ts
+++ b/test/integration/process/distribution.scenario-auto-associated-distribution-scenario.spec.ts
@@ -196,7 +196,7 @@ describe('fully auto-associated distribution scenario', function () {
 					const payment = finalResult.payments[i];
 					expect(payment.index).to.equal(i);
 					expect(payment.account).to.equal(accountInfo.receipt.accountId.toString());
-					expect(payment.status).to.equal('Status: Distribution Completed');
+					expect(payment.status).to.equal('Distribution Completed');
 					expect(payment).has.property('schedulingTx');
 					expect(payment).has.property('scheduledTx');
 					expect(payment).has.property('scheduleId');
@@ -229,7 +229,7 @@ describe('fully auto-associated distribution scenario', function () {
 						expect(record[6]).to.equal('SUCCESS');
 						expect(record[7]).to.not.be.empty;
 						expect(record[8]).to.equal('SUCCESS');
-						expect(record[9]).to.equal(`Status: Distribution Completed`);
+						expect(record[9]).to.equal(`Distribution Completed`);
 					}
 					count = count + 1;
 				}

--- a/test/integration/process/distribution.scenario-fully-associated-distribution.spec.ts
+++ b/test/integration/process/distribution.scenario-fully-associated-distribution.spec.ts
@@ -182,7 +182,7 @@ describe('fully associated distribution scenario', function () {
 					const payment = finalResult.payments[i];
 					expect(payment.index).to.equal(i);
 					expect(payment.account).to.equal(accountInfo.receipt.accountId.toString());
-					expect(payment.status).to.equal('Status: Distribution Completed');
+					expect(payment.status).to.equal('Distribution Completed');
 					expect(payment).has.property('schedulingTx');
 					expect(payment).has.property('scheduledTx');
 					expect(payment).has.property('scheduleId');
@@ -215,7 +215,7 @@ describe('fully associated distribution scenario', function () {
 						expect(record[6]).to.equal('SUCCESS');
 						expect(record[7]).to.not.be.empty;
 						expect(record[8]).to.equal('SUCCESS');
-						expect(record[9]).to.equal(`Status: Distribution Completed`);
+						expect(record[9]).to.equal(`Distribution Completed`);
 					}
 					count = count + 1;
 				}
@@ -381,7 +381,7 @@ describe('fully associated distribution scenario', function () {
 					const payment = finalResult.payments[i];
 					expect(payment.index).to.equal(i);
 					expect(payment.account).to.equal(accountInfo.receipt.accountId.toString());
-					expect(payment.status).to.equal('Status: Distribution Completed');
+					expect(payment.status).to.equal('Distribution Completed');
 					expect(payment).has.property('schedulingTx');
 					expect(payment).has.property('scheduledTx');
 					expect(payment).has.property('scheduleId');
@@ -414,7 +414,7 @@ describe('fully associated distribution scenario', function () {
 						expect(record[6]).to.equal('SUCCESS');
 						expect(record[7]).to.not.be.empty;
 						expect(record[8]).to.equal('SUCCESS');
-						expect(record[9]).to.equal(`Status: Distribution Completed`);
+						expect(record[9]).to.equal(`Distribution Completed`);
 					}
 					count = count + 1;
 				}

--- a/test/integration/process/distribution.scenario-partial-autoassociated-distribution.spec.ts
+++ b/test/integration/process/distribution.scenario-partial-autoassociated-distribution.spec.ts
@@ -196,7 +196,7 @@ describe('partial auto-associated distribution scenario', function () {
 					const payment = finalResult.payments[i];
 					expect(payment.index).to.equal(i);
 					expect(payment.account).to.equal(accountInfo.receipt.accountId.toString());
-					expect(payment.status).to.equal('Status: Distribution Completed');
+					expect(payment.status).to.equal('Distribution Completed');
 					expect(payment).has.property('schedulingTx');
 					expect(payment).has.property('scheduledTx');
 					expect(payment).has.property('scheduleId');
@@ -229,7 +229,7 @@ describe('partial auto-associated distribution scenario', function () {
 						expect(record[6]).to.equal('SUCCESS');
 						expect(record[7]).to.not.be.empty;
 						expect(record[8]).to.equal('SUCCESS');
-						expect(record[9]).to.equal(`Status: Distribution Completed`);
+						expect(record[9]).to.equal(`Distribution Completed`);
 					}
 					count = count + 1;
 				}


### PR DESCRIPTION
This PR removes the `Status:` message and will only return `Distribution Success`.

Fixes #30.