### PR TITLE
Fixes #18  Add Timestamps to Output File

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creators-galaxy/token-distribution-tool",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Creator's Galaxy Token Distribution Tool",
   "author": "Calaxy, Inc.",
   "license": "MIT",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -65,7 +65,7 @@ export default [{
 		}),
 		production && terser()
 	],
-	external: ['electron', 'os', 'fs', 'csv-parse', 'csv-stringify', 'worker_threads', '@hashgraph/sdk', '@hashgraph/cryptography', '@hashgraph/proto', 'bignumber.js'],
+	external: ['electron', 'os', 'fs', 'csv-parse', 'csv-stringify', 'worker_threads', 'https', '@hashgraph/sdk', '@hashgraph/cryptography', '@hashgraph/proto', 'bignumber.js'],
 	watch: {
 		clearScreen: false
 	}

--- a/test/integration/process/distribution.scenario-auto-associated-distribution-scenario.spec.ts
+++ b/test/integration/process/distribution.scenario-auto-associated-distribution-scenario.spec.ts
@@ -113,6 +113,10 @@ describe('fully auto-associated distribution scenario', function () {
 						expect(record[7]).to.equal('Scheduled Payment Tx Id');
 						expect(record[8]).to.equal('Scheduled Payment Tx Status');
 						expect(record[9]).to.equal('Status Description');
+						expect(record[10]).to.equal('Started');
+						expect(record[11]).to.equal('Scheduled');
+						expect(record[12]).to.equal('Countersigned');
+						expect(record[13]).to.equal('Finished');
 					} else {
 						const payment = finalResult.payments[count - 1];
 						expect(record[0]).to.equal(payment.account);
@@ -125,6 +129,10 @@ describe('fully auto-associated distribution scenario', function () {
 						expect(record[7]).to.not.be.empty;
 						expect(record[8]).to.equal('RECEIPT_NOT_FOUND');
 						expect(record[9]).to.equal(`Scheduling: Awaiting Add'l Signatures`);
+						expect(record[10]).to.not.be.empty;
+						expect(record[11]).to.not.be.empty;
+						expect(record[12]).to.equal('n/a');
+						expect(record[13]).to.not.be.empty;
 					}
 					count = count + 1;
 				}
@@ -218,6 +226,10 @@ describe('fully auto-associated distribution scenario', function () {
 						expect(record[7]).to.equal('Scheduled Payment Tx Id');
 						expect(record[8]).to.equal('Scheduled Payment Tx Status');
 						expect(record[9]).to.equal('Status Description');
+						expect(record[10]).to.equal('Started');
+						expect(record[11]).to.equal('Scheduled');
+						expect(record[12]).to.equal('Countersigned');
+						expect(record[13]).to.equal('Finished');
 					} else {
 						const payment = finalResult.payments[count - 1];
 						expect(record[0]).to.equal(payment.account);
@@ -230,6 +242,13 @@ describe('fully auto-associated distribution scenario', function () {
 						expect(record[7]).to.not.be.empty;
 						expect(record[8]).to.equal('SUCCESS');
 						expect(record[9]).to.equal(`Status: Distribution Completed`);
+						expect(record[10]).to.not.be.empty;
+						expect(record[11]).to.not.be.empty;
+						expect(record[12]).to.not.be.empty;
+						expect(record[13]).to.not.be.empty;
+						expect(Date.parse(record[10])).to.be.lessThan(Date.parse(record[11]));
+						expect(Date.parse(record[11])).to.be.lessThan(Date.parse(record[12]));
+						expect(Date.parse(record[12])).to.be.lessThan(Date.parse(record[13]));
 					}
 					count = count + 1;
 				}

--- a/test/integration/process/distribution.scenario-fully-associated-distribution.spec.ts
+++ b/test/integration/process/distribution.scenario-fully-associated-distribution.spec.ts
@@ -106,6 +106,10 @@ describe('fully associated distribution scenario', function () {
 						expect(record[7]).to.equal('Scheduled Payment Tx Id');
 						expect(record[8]).to.equal('Scheduled Payment Tx Status');
 						expect(record[9]).to.equal('Status Description');
+						expect(record[10]).to.equal('Started');
+						expect(record[11]).to.equal('Scheduled');
+						expect(record[12]).to.equal('Countersigned');
+						expect(record[13]).to.equal('Finished');
 					} else {
 						const payment = finalResult.payments[count - 1];
 						expect(record[0]).to.equal(payment.account);
@@ -118,6 +122,10 @@ describe('fully associated distribution scenario', function () {
 						expect(record[7]).to.not.be.empty;
 						expect(record[8]).to.equal('RECEIPT_NOT_FOUND');
 						expect(record[9]).to.equal(`Scheduling: Awaiting Add'l Signatures`);
+						expect(record[10]).to.not.be.empty;
+						expect(record[11]).to.not.be.empty;
+						expect(record[12]).to.equal('n/a');
+						expect(record[13]).to.not.be.empty;
 					}
 					count = count + 1;
 				}
@@ -204,6 +212,10 @@ describe('fully associated distribution scenario', function () {
 						expect(record[7]).to.equal('Scheduled Payment Tx Id');
 						expect(record[8]).to.equal('Scheduled Payment Tx Status');
 						expect(record[9]).to.equal('Status Description');
+						expect(record[10]).to.equal('Started');
+						expect(record[11]).to.equal('Scheduled');
+						expect(record[12]).to.equal('Countersigned');
+						expect(record[13]).to.equal('Finished');
 					} else {
 						const payment = finalResult.payments[count - 1];
 						expect(record[0]).to.equal(payment.account);
@@ -216,6 +228,10 @@ describe('fully associated distribution scenario', function () {
 						expect(record[7]).to.not.be.empty;
 						expect(record[8]).to.equal('SUCCESS');
 						expect(record[9]).to.equal(`Status: Distribution Completed`);
+						expect(record[10]).to.not.be.empty;
+						expect(record[11]).to.not.be.empty;
+						expect(record[12]).to.not.be.empty;
+						expect(record[13]).to.not.be.empty;
 					}
 					count = count + 1;
 				}
@@ -309,6 +325,10 @@ describe('fully associated distribution scenario', function () {
 						expect(record[7]).to.equal('Scheduled Payment Tx Id');
 						expect(record[8]).to.equal('Scheduled Payment Tx Status');
 						expect(record[9]).to.equal('Status Description');
+						expect(record[10]).to.equal('Started');
+						expect(record[11]).to.equal('Scheduled');
+						expect(record[12]).to.equal('Countersigned');
+						expect(record[13]).to.equal('Finished');
 					} else {
 						const payment = finalResult.payments[count - 1];
 						expect(record[0]).to.equal(payment.account);
@@ -321,6 +341,10 @@ describe('fully associated distribution scenario', function () {
 						expect(record[7]).to.not.be.empty;
 						expect(record[8]).to.equal('RECEIPT_NOT_FOUND');
 						expect(record[9]).to.equal(`Scheduling: Awaiting Add'l Signatures`);
+						expect(record[10]).to.not.be.empty;
+						expect(record[11]).to.not.be.empty;
+						expect(record[12]).to.equal('n/a');
+						expect(record[13]).to.not.be.empty;
 					}
 					count = count + 1;
 				}
@@ -403,6 +427,10 @@ describe('fully associated distribution scenario', function () {
 						expect(record[7]).to.equal('Scheduled Payment Tx Id');
 						expect(record[8]).to.equal('Scheduled Payment Tx Status');
 						expect(record[9]).to.equal('Status Description');
+						expect(record[10]).to.equal('Started');
+						expect(record[11]).to.equal('Scheduled');
+						expect(record[12]).to.equal('Countersigned');
+						expect(record[13]).to.equal('Finished');
 					} else {
 						const payment = finalResult.payments[count - 1];
 						expect(record[0]).to.equal(payment.account);
@@ -415,6 +443,10 @@ describe('fully associated distribution scenario', function () {
 						expect(record[7]).to.not.be.empty;
 						expect(record[8]).to.equal('SUCCESS');
 						expect(record[9]).to.equal(`Status: Distribution Completed`);
+						expect(record[10]).to.not.be.empty;
+						expect(record[11]).to.not.be.empty;
+						expect(record[12]).to.not.be.empty;
+						expect(record[13]).to.not.be.empty;
 					}
 					count = count + 1;
 				}

--- a/test/integration/process/distribution.scenario-no-associated-distribution-scenario.spec.ts
+++ b/test/integration/process/distribution.scenario-no-associated-distribution-scenario.spec.ts
@@ -113,6 +113,10 @@ describe('no associations distribution scenario', function () {
 						expect(record[7]).to.equal('Scheduled Payment Tx Id');
 						expect(record[8]).to.equal('Scheduled Payment Tx Status');
 						expect(record[9]).to.equal('Status Description');
+						expect(record[10]).to.equal('Started');
+						expect(record[11]).to.equal('Scheduled');
+						expect(record[12]).to.equal('Countersigned');
+						expect(record[13]).to.equal('Finished');
 					} else {
 						const payment = finalResult.payments[count - 1];
 						expect(record[0]).to.equal(payment.account);
@@ -125,6 +129,10 @@ describe('no associations distribution scenario', function () {
 						expect(record[7]).to.not.be.empty;
 						expect(record[8]).to.equal('RECEIPT_NOT_FOUND');
 						expect(record[9]).to.equal(`Scheduling: Awaiting Add'l Signatures`);
+						expect(record[10]).to.not.be.empty;
+						expect(record[11]).to.not.be.empty;
+						expect(record[12]).to.equal('n/a');
+						expect(record[13]).to.not.be.empty;
 					}
 					count = count + 1;
 				}
@@ -224,6 +232,10 @@ describe('no associations distribution scenario', function () {
 						expect(record[7]).to.equal('Scheduled Payment Tx Id');
 						expect(record[8]).to.equal('Scheduled Payment Tx Status');
 						expect(record[9]).to.equal('Status Description');
+						expect(record[10]).to.equal('Started');
+						expect(record[11]).to.equal('Scheduled');
+						expect(record[12]).to.equal('Countersigned');
+						expect(record[13]).to.equal('Finished');
 					} else {
 						const payment = finalResult.payments[count - 1];
 						expect(record[0]).to.equal(payment.account);
@@ -236,6 +248,10 @@ describe('no associations distribution scenario', function () {
 						expect(record[7]).to.not.be.empty;
 						expect(record[8]).to.equal('TOKEN_NOT_ASSOCIATED_TO_ACCOUNT');
 						expect(record[9]).to.equal(`Status: TOKEN_NOT_ASSOCIATED_TO_ACCOUNT`);
+						expect(record[10]).to.not.be.empty;
+						expect(record[11]).to.not.be.empty;
+						expect(record[12]).to.not.be.empty;
+						expect(record[13]).to.not.be.empty;
 					}
 					count = count + 1;
 				}

--- a/test/integration/process/distribution.scenario-partial-autoassociated-distribution.spec.ts
+++ b/test/integration/process/distribution.scenario-partial-autoassociated-distribution.spec.ts
@@ -113,6 +113,10 @@ describe('partial auto-associated distribution scenario', function () {
 						expect(record[7]).to.equal('Scheduled Payment Tx Id');
 						expect(record[8]).to.equal('Scheduled Payment Tx Status');
 						expect(record[9]).to.equal('Status Description');
+						expect(record[10]).to.equal('Started');
+						expect(record[11]).to.equal('Scheduled');
+						expect(record[12]).to.equal('Countersigned');
+						expect(record[13]).to.equal('Finished');
 					} else {
 						const payment = finalResult.payments[count - 1];
 						expect(record[0]).to.equal(payment.account);
@@ -125,6 +129,10 @@ describe('partial auto-associated distribution scenario', function () {
 						expect(record[7]).to.not.be.empty;
 						expect(record[8]).to.equal('RECEIPT_NOT_FOUND');
 						expect(record[9]).to.equal(`Scheduling: Awaiting Add'l Signatures`);
+						expect(record[10]).to.not.be.empty;
+						expect(record[11]).to.not.be.empty;
+						expect(record[12]).to.equal('n/a');
+						expect(record[13]).to.not.be.empty;
 					}
 					count = count + 1;
 				}
@@ -218,6 +226,10 @@ describe('partial auto-associated distribution scenario', function () {
 						expect(record[7]).to.equal('Scheduled Payment Tx Id');
 						expect(record[8]).to.equal('Scheduled Payment Tx Status');
 						expect(record[9]).to.equal('Status Description');
+						expect(record[10]).to.equal('Started');
+						expect(record[11]).to.equal('Scheduled');
+						expect(record[12]).to.equal('Countersigned');
+						expect(record[13]).to.equal('Finished');
 					} else {
 						const payment = finalResult.payments[count - 1];
 						expect(record[0]).to.equal(payment.account);
@@ -230,6 +242,10 @@ describe('partial auto-associated distribution scenario', function () {
 						expect(record[7]).to.not.be.empty;
 						expect(record[8]).to.equal('SUCCESS');
 						expect(record[9]).to.equal(`Status: Distribution Completed`);
+						expect(record[10]).to.not.be.empty;
+						expect(record[11]).to.not.be.empty;
+						expect(record[12]).to.not.be.empty;
+						expect(record[13]).to.not.be.empty;
 					}
 					count = count + 1;
 				}


### PR DESCRIPTION
Added additional information to the output
file created when downloading the results of
a distribution.  The new data includes the date
and time when the application started and
finished processing a distribution.