### PR TITLE
Change to DragonGlass & HashScan Explorers

### DIFF
--- a/src/app/components/AccountInfoDialog.svelte
+++ b/src/app/components/AccountInfoDialog.svelte
@@ -1,14 +1,16 @@
-<script lang="ts">
+<script lang="ts">    
     import { ExplorerId } from "../../common/primitives";
     import { invoke } from "../common/ipc";
     
     let dialog;    
     let title;    
     let info;
+    let showJson;
    
     export function showDialog(accountId: string) {
         title = `Account ${accountId}`;
         info = null;
+        showJson = false;
         invoke('get-account-info', accountId).then( value => info = value ); 
         dialog.showModal();
     }
@@ -24,6 +26,14 @@
     function onOpenHashScan() {
         invoke('open-account-explorer', info.accountId, ExplorerId.HashScan);
     }
+
+    function onShowJson() {
+        showJson = true;
+    }
+
+    function onShowDetails() {
+        showJson = false;
+    }
 </script>
 
 <dialog bind:this={dialog}>
@@ -31,7 +41,10 @@
         <button on:click={onClose} class="close-dialog"></button>                
         <h1>{title}</h1>
         <div>
-            {#if info}                
+            {#if info && showJson}         
+                <div class="json">{JSON.stringify(info.raw,null,2)}</div>
+                <div class="action" on:click={onShowDetails}>Show Summary</div>
+            {:else if info}                
                 {#if info.timestamp}
                     <h2><span class="network">{info.network}</span> as of <i>{info.timestamp}</i></h2>
                 {:else}
@@ -49,10 +62,13 @@
                         <div>Token <i>{token_id}</i> {balance}</div>
                     {/each}
                 {/if}
-                <div class="lookup">More info on</div>
+                <div class="lookup">More info</div>
                 <ul>
-                    <li on:click={onOpenDragonglass}>DragonGlass</li>
-                    <li on:click={onOpenHashScan}>HashScan</li>
+                    <li class="action" on:click={onOpenDragonglass}>DragonGlass</li>
+                    <li class="action" on:click={onOpenHashScan}>HashScan</li>
+                    {#if info.raw}
+                        <li class="action" on:click={onShowJson}>Show Mirror JSON</li>
+                    {/if}
                 </ul>
             {:else}
                 <div>Retrieving current info ...</div>
@@ -66,13 +82,15 @@
         display: grid;
         grid-template-rows: max-content max-content 1fr;
         margin: 0;
-        padding: 0;
+        padding: 0 0 1rem 0;
         width: min(90vw, 28rem);
         min-height: 17rem;
         color: var(--cds-nl-0);
     }
     dialog > section > div {
         padding: 0 3rem;
+        overflow-x: hidden;
+        overflow-y: auto;
     }
     h1 {
         margin: 0 3rem;
@@ -100,11 +118,15 @@
     ul {
         margin: 0;
     }
-    li {
+    .action {
         cursor: pointer;
     }
-    li:active, li:focus, li:hover {
+    .action:active, .action:focus, .action:hover {
         color: var(--cds-cs-500);
         text-decoration: underline;
+    }
+    .json {
+        white-space: pre;
+        overflow-y: auto;
     }
 </style>

--- a/src/app/components/AccountInfoDialog.svelte
+++ b/src/app/components/AccountInfoDialog.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+    import { ExplorerId } from "../../common/primitives";
+    import { invoke } from "../common/ipc";
+    
+    let dialog;    
+    let title;    
+    let info;
+   
+    export function showDialog(accountId: string) {
+        title = `Account ${accountId}`;
+        info = null;
+        invoke('get-account-info', accountId).then( value => info = value ); 
+        dialog.showModal();
+    }
+
+    function onClose() {
+        dialog.close();
+    }
+
+    function onOpenDragonglass() {
+        invoke('open-account-explorer', info.accountId, ExplorerId.DragonGlass);
+    }
+
+    function onOpenHashScan() {
+        invoke('open-account-explorer', info.accountId, ExplorerId.HashScan);
+    }
+</script>
+
+<dialog bind:this={dialog}>
+    <section>
+        <button on:click={onClose} class="close-dialog"></button>                
+        <h1>{title}</h1>
+        <div>
+            {#if info}                
+                {#if info.timestamp}
+                    <h2><span class="network">{info.network}</span> as of <i>{info.timestamp}</i></h2>
+                {:else}
+                    <h2><span class="network">{info.network}</span></h2>
+                {/if}
+                {#if info.error}
+                    <div>{info.error}</div>
+                {:else}
+                    {#if info.balance}
+                        <div>Crypto <i>(tℏ)</i> {info.balance}</div>
+                    {:else}
+                        <div>No crypto balance</div>
+                    {/if}
+                    {#each info.tokens as {token_id, balance}}
+                        <div>Token <i>{token_id}</i> {balance}</div>
+                    {/each}
+                {/if}
+                <div class="lookup">More info on</div>
+                <ul>
+                    <li on:click={onOpenDragonglass}>DragonGlass</li>
+                    <li on:click={onOpenHashScan}>HashScan</li>
+                </ul>
+            {:else}
+                <div>Retrieving current info ...</div>
+            {/if}
+        </div>
+    </section>
+</dialog>
+
+<style>
+    dialog > section {
+        display: grid;
+        grid-template-rows: max-content max-content 1fr;
+        margin: 0;
+        padding: 0;
+        width: min(90vw, 28rem);
+        min-height: 17rem;
+        color: var(--cds-nl-0);
+    }
+    dialog > section > div {
+        padding: 0 3rem;
+    }
+    h1 {
+        margin: 0 3rem;
+        padding: 0;
+        font-weight: 600;
+        font-size: 1.25rem;
+    }
+    h2 {
+        margin: 0 0 1rem 0;
+        padding: 0;
+        font-weight: 300;
+        font-size: 1rem;
+        line-height: 1;
+    }
+    button.close-dialog {
+        justify-self: end;        
+        margin: 1rem 1rem 0 0;
+    }
+	.network, i {
+		color: var(--cds-cs-500);
+	}
+    .lookup {
+        margin-top: 1rem;
+    }
+    ul {
+        margin: 0;
+    }
+    li {
+        cursor: pointer;
+    }
+    li:active, li:focus, li:hover {
+        color: var(--cds-cs-500);
+        text-decoration: underline;
+    }
+</style>

--- a/src/app/components/DistributionsTable.svelte
+++ b/src/app/components/DistributionsTable.svelte
@@ -1,9 +1,17 @@
 <script lang="ts">
-import { PaymentStage, PaymentStep } from "../../common/primitives";
-
-    import { invoke } from "../common/ipc";
+    import { PaymentStage, PaymentStep } from "../../common/primitives";
+    import AccountInfoDialog from "./AccountInfoDialog.svelte";
+    import ScheduleInfoDialog from "./ScheduleInfoDialog.svelte";
+    import TransactionInfoDialog from "./TransactionInfoDialog.svelte";
+    import ScheduledTransactionInfoDialog from "./ScheduledTransactionInfoDialog.svelte";
 
     export let payments: any[];
+
+    let accountInfoDialog: AccountInfoDialog;
+    let scheduleInfoDialog: ScheduleInfoDialog;
+    let transactionInfoDialog: TransactionInfoDialog;
+    let scheduledTransactionInfoDialog: ScheduledTransactionInfoDialog;
+
 
     // this is a little more complex than otherwise
     // would usually create, we don't have to have 
@@ -20,13 +28,13 @@ import { PaymentStage, PaymentStep } from "../../common/primitives";
                     const payment = payments[index-1];
                     if(payment) {
                         if(cellType === 'address') {
-                            await invoke('open-address-explorer',payment.account);
+                            accountInfoDialog.showDialog(payment.account);
                         } else if(cellType === 'schedule') {
-                            await invoke('open-address-explorer',payment.scheduleId);
+                            scheduleInfoDialog.showDialog(payment.scheduleId);
                         } else if(cellType === 'scheduling-tx') {
-                            await invoke('open-transaction-explorer', payment.schedulingTx);
+                            transactionInfoDialog.showDialog(payment.schedulingTx);
                         } else if(cellType === 'scheduled-tx') {
-                            await invoke('open-scheduled-transaction-explorer', payment.scheduleId);
+                            scheduledTransactionInfoDialog.showDialog(payment.scheduleId, payment.scheduledTx);
                         }
                     }
                 }
@@ -88,6 +96,10 @@ import { PaymentStage, PaymentStep } from "../../common/primitives";
         </tr>
         {/each}
     </table>
+    <AccountInfoDialog bind:this={accountInfoDialog}/>
+    <ScheduleInfoDialog bind:this={scheduleInfoDialog}/>
+    <TransactionInfoDialog bind:this={transactionInfoDialog}/>
+    <ScheduledTransactionInfoDialog bind:this={scheduledTransactionInfoDialog}/>
 </div>
 <style>
     div.container {

--- a/src/app/components/ScheduleInfoDialog.svelte
+++ b/src/app/components/ScheduleInfoDialog.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+    import { invoke } from "../common/ipc";
+    
+    let dialog;    
+    let title;    
+    let info;
+   
+    export function showDialog(scheduleId: string) {
+        title = `Schedule ${scheduleId}`;
+        info = null;
+        invoke('get-schedule-info', scheduleId).then( value => info = value ); 
+        dialog.showModal();
+    }
+
+    function onClose() {
+        dialog.close();
+    }
+
+    function onOpenDragonglass() {
+        invoke('open-schedule-explorer', info.scheduleId);
+    }
+</script>
+
+<dialog bind:this={dialog}>
+    <section>
+        <button on:click={onClose} class="close-dialog"></button>                
+        <h1>{title}</h1>
+        <div>
+            {#if info}                
+                <h2><span class="network">{info.network}</span></h2>
+                {#if info.error}
+                    <div>{info.error}</div>
+                {:else}
+                    <div>Created on <i>{info.timestamp}</i> by {info.createdById}</div>
+                    <div>Paying account {info.payerId}</div>
+                    {#if info.executed}
+                        <div>Completed on <i>{info.executed}</i></div>
+                    {:else}
+                        <div>Not Completed, Signed By</div>
+                        <ul>
+                            {#each info.signingKeys as key}
+                                <li>{key}</li>
+                            {/each}
+                        </ul>
+                    {/if}
+                {/if}
+                <div class="lookup">More info on</div>
+                <ul>
+                    <li class="link" on:click={onOpenDragonglass}>DragonGlass</li>
+                </ul>
+            {:else}
+                <div>Retrieving current info ...</div>
+            {/if}
+        </div>
+    </section>
+</dialog>
+
+<style>
+    dialog > section {
+        display: grid;
+        grid-template-rows: max-content max-content 1fr;
+        margin: 0;
+        padding: 0;
+        width: min(90vw, 28rem);
+        min-height: 17rem;
+        color: var(--cds-nl-0);
+        overflow: hidden;
+    }
+    dialog > section > div {
+        padding: 0 3rem 1rem 3rem;
+        overflow-x: hidden;
+        overflow-y: auto;
+    }
+    h1 {
+        margin: 0 3rem;
+        padding: 0;
+        font-weight: 600;
+        font-size: 1.25rem;
+    }
+    h2 {
+        margin: 0 0 1rem 0;
+        padding: 0;
+        font-weight: 300;
+        font-size: 1rem;
+        line-height: 1;
+    }
+    button.close-dialog {
+        justify-self: end;        
+        margin: 1rem 1rem 0 0;
+    }
+	.network, i {
+		color: var(--cds-cs-500);
+	}
+    .lookup {
+        margin-top: 1rem;
+    }
+    ul {
+        margin: 0;
+    }
+    li {
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+    li.link {
+        cursor: pointer;
+    }
+    li.link:active, li.link:focus, li.link:hover {
+        color: var(--cds-cs-500);
+        text-decoration: underline;
+    }
+</style>

--- a/src/app/components/ScheduleInfoDialog.svelte
+++ b/src/app/components/ScheduleInfoDialog.svelte
@@ -4,10 +4,12 @@
     let dialog;    
     let title;    
     let info;
+    let showJson;
    
     export function showDialog(scheduleId: string) {
         title = `Schedule ${scheduleId}`;
         info = null;
+        showJson = false;
         invoke('get-schedule-info', scheduleId).then( value => info = value ); 
         dialog.showModal();
     }
@@ -16,9 +18,13 @@
         dialog.close();
     }
 
-    function onOpenDragonglass() {
-        invoke('open-schedule-explorer', info.scheduleId);
+    function onShowJson() {
+        showJson = true;
     }
+
+    function onShowDetails() {
+        showJson = false;
+    }    
 </script>
 
 <dialog bind:this={dialog}>
@@ -26,7 +32,10 @@
         <button on:click={onClose} class="close-dialog"></button>                
         <h1>{title}</h1>
         <div>
-            {#if info}                
+            {#if info && showJson}         
+                <div class="json">{JSON.stringify(info.raw,null,2)}</div>
+                <div class="action" on:click={onShowDetails}>Show Summary</div>
+            {:else if info}                
                 <h2><span class="network">{info.network}</span></h2>
                 {#if info.error}
                     <div>{info.error}</div>
@@ -44,10 +53,12 @@
                         </ul>
                     {/if}
                 {/if}
-                <div class="lookup">More info on</div>
-                <ul>
-                    <li class="link" on:click={onOpenDragonglass}>DragonGlass</li>
-                </ul>
+                {#if info.raw}
+                    <div class="lookup">More info</div>
+                    <ul>
+                        <li class="action" on:click={onShowJson}>Show Mirror JSON</li>
+                    </ul>
+                {/if}
             {:else}
                 <div>Retrieving current info ...</div>
             {/if}
@@ -60,11 +71,10 @@
         display: grid;
         grid-template-rows: max-content max-content 1fr;
         margin: 0;
-        padding: 0;
+        padding: 0 0 1rem 0;
         width: min(90vw, 28rem);
         min-height: 17rem;
         color: var(--cds-nl-0);
-        overflow: hidden;
     }
     dialog > section > div {
         padding: 0 3rem 1rem 3rem;
@@ -101,11 +111,15 @@
         overflow: hidden;
         text-overflow: ellipsis;
     }
-    li.link {
+    .action {
         cursor: pointer;
     }
-    li.link:active, li.link:focus, li.link:hover {
+    .action:active, .action:focus, .action:hover {
         color: var(--cds-cs-500);
         text-decoration: underline;
+    }
+    .json {
+        white-space: pre;
+        overflow-y: auto;
     }
 </style>

--- a/src/app/components/ScheduledTransactionInfoDialog.svelte
+++ b/src/app/components/ScheduledTransactionInfoDialog.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+    import { displayEpochString } from "../../common/convert";
+    import { ExplorerId } from "../../common/primitives";
+    import { invoke } from "../common/ipc";
+    
+    let dialog;    
+    let title;    
+    let info;
+   
+    export function showDialog(scheduleId: string, scheduledTx: string) {
+        title = `Distribution Transaction ${scheduledTx}`;
+        info = null;
+        invoke('get-schedule-info', scheduleId).then( scheduleInfo => {
+            if(scheduleInfo.error) {
+                info = { error: scheduleInfo.error, network: scheduleInfo.network };
+            } else if(scheduleInfo.executed) {
+                const [accountId, timestampWithFlags] = scheduledTx.split('@');
+                const [timestamp, scheduled] = timestampWithFlags.split('?');
+                const [secondsString, nanosString] = timestamp.split('.');
+                const seconds = parseInt(secondsString,10);
+                const nanos = parseInt(nanosString,10);
+                invoke('get-transaction-info', accountId, seconds, nanos, true).then( value => info = value );
+            } else {
+                info = { 
+                    error: `Distribution ${scheduleId} is awaiting additional countersignatures and has not been completed, there is no transaction to review.`,
+                    network: scheduleInfo.network
+                };
+            }
+        } ); 
+        dialog.showModal();
+    }
+
+    function onClose() {
+        dialog.close();
+    }
+
+    function onOpenDragonglass() {
+        invoke('open-transaction-explorer', info.txId, ExplorerId.DragonGlass);
+    }
+
+    function onOpenHashScan() {
+        invoke('open-transaction-explorer', info.txId, ExplorerId.HashScan);
+    }
+</script>
+
+<dialog bind:this={dialog}>
+    <section>
+        <button on:click={onClose} class="close-dialog"></button>                
+        <h1>{title}</h1>
+        <div>
+            {#if info}                
+                <h2><span class="network">{info.network}</span></h2>
+                {#if info.error}
+                    <div>{info.error}</div>
+                {:else}
+                    <div>{displayEpochString(info.consensus_timestamp)}</div>
+                    <div>{info.name}</div>
+                    <div>{info.result}</div>                    
+                    <div class="lookup">More info on</div>
+                    <ul>
+                        <li on:click={onOpenDragonglass}>DragonGlass</li>
+                        <li on:click={onOpenHashScan}>HashScan</li>
+                    </ul>
+                {/if}
+            {:else}
+                <div>Retrieving current info ...</div>
+            {/if}
+        </div>
+    </section>
+</dialog>
+
+<style>
+    dialog > section {
+        display: grid;
+        grid-template-rows: max-content max-content 1fr;
+        margin: 0;
+        padding: 0;
+        width: min(90vw, 36rem);
+        min-height: 17rem;
+        color: var(--cds-nl-0);
+    }
+    dialog > section > div {
+        padding: 0 3rem 1rem 3rem;
+    }
+    h1 {
+        margin: 0 3rem;
+        padding: 0;
+        font-weight: 600;
+        font-size: 1.25rem;
+    }
+    h2 {
+        margin: 0 0 1rem 0;
+        padding: 0;
+        font-weight: 300;
+        font-size: 1rem;
+        line-height: 1;
+    }
+    button.close-dialog {
+        justify-self: end;        
+        margin: 1rem 1rem 0 0;
+    }
+	.network, i {
+		color: var(--cds-cs-500);
+	}
+    .lookup {
+        margin-top: 1rem;
+    }
+    ul {
+        margin: 0;
+    }
+    li {
+        cursor: pointer;
+    }
+    li:active, li:focus, li:hover {
+        color: var(--cds-cs-500);
+        text-decoration: underline;
+    }
+</style>

--- a/src/app/components/ScheduledTransactionInfoDialog.svelte
+++ b/src/app/components/ScheduledTransactionInfoDialog.svelte
@@ -6,10 +6,12 @@
     let dialog;    
     let title;    
     let info;
+    let showJson;
    
     export function showDialog(scheduleId: string, scheduledTx: string) {
         title = `Distribution Transaction ${scheduledTx}`;
         info = null;
+        showJson = false;
         invoke('get-schedule-info', scheduleId).then( scheduleInfo => {
             if(scheduleInfo.error) {
                 info = { error: scheduleInfo.error, network: scheduleInfo.network };
@@ -41,6 +43,14 @@
     function onOpenHashScan() {
         invoke('open-transaction-explorer', info.txId, ExplorerId.HashScan);
     }
+
+    function onShowJson() {
+        showJson = true;
+    }
+
+    function onShowDetails() {
+        showJson = false;
+    }    
 </script>
 
 <dialog bind:this={dialog}>
@@ -48,7 +58,10 @@
         <button on:click={onClose} class="close-dialog"></button>                
         <h1>{title}</h1>
         <div>
-            {#if info}                
+            {#if info && showJson}         
+                <div class="json">{JSON.stringify(info.raw,null,2)}</div>
+                <div class="action" on:click={onShowDetails}>Show Summary</div>
+            {:else if info}                
                 <h2><span class="network">{info.network}</span></h2>
                 {#if info.error}
                     <div>{info.error}</div>
@@ -56,10 +69,13 @@
                     <div>{displayEpochString(info.consensus_timestamp)}</div>
                     <div>{info.name}</div>
                     <div>{info.result}</div>                    
-                    <div class="lookup">More info on</div>
+                    <div class="lookup">More info</div>
                     <ul>
-                        <li on:click={onOpenDragonglass}>DragonGlass</li>
-                        <li on:click={onOpenHashScan}>HashScan</li>
+                        <li class="action" on:click={onOpenDragonglass}>DragonGlass</li>
+                        <li class="action" on:click={onOpenHashScan}>HashScan</li>
+                        {#if info.raw}
+                            <li class="action" on:click={onShowJson}>Show Mirror JSON</li>
+                        {/if}
                     </ul>
                 {/if}
             {:else}
@@ -74,13 +90,15 @@
         display: grid;
         grid-template-rows: max-content max-content 1fr;
         margin: 0;
-        padding: 0;
+        padding: 0 0 1rem 0;
         width: min(90vw, 36rem);
         min-height: 17rem;
         color: var(--cds-nl-0);
     }
     dialog > section > div {
         padding: 0 3rem 1rem 3rem;
+        overflow-x: hidden;
+        overflow-y: auto;
     }
     h1 {
         margin: 0 3rem;
@@ -108,11 +126,15 @@
     ul {
         margin: 0;
     }
-    li {
+    .action {
         cursor: pointer;
     }
-    li:active, li:focus, li:hover {
+    .action:active, .action:focus, .action:hover {
         color: var(--cds-cs-500);
         text-decoration: underline;
     }
-</style>
+    .json {
+        white-space: pre;
+        overflow-y: auto;
+    }
+    </style>

--- a/src/app/components/TransactionInfoDialog.svelte
+++ b/src/app/components/TransactionInfoDialog.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+import { displayEpochString } from "../../common/convert";
+
+    import { ExplorerId } from "../../common/primitives";
+    import { invoke } from "../common/ipc";
+    
+    let dialog;    
+    let title;    
+    let info;
+   
+    export function showDialog(transactionId: string) {
+        const [accountId, timestampWithFlags] = transactionId.split('@');
+        const [timestamp, scheduled] = timestampWithFlags.split('?');
+        const [secondsString, nanosString] = timestamp.split('.');
+        const seconds = parseInt(secondsString,10);
+        const nanos = parseInt(nanosString,10);
+        const isScheduled = scheduled === 'scheduled';
+        title = `${ isScheduled ? 'Scheduled ' : ''}Transaction ${transactionId}`;
+        info = null;
+        invoke('get-transaction-info', accountId, seconds, nanos, isScheduled).then( value => info = value );
+        dialog.showModal();
+    }
+
+    function onClose() {
+        dialog.close();
+    }
+
+    function onOpenDragonglass() {
+        invoke('open-transaction-explorer', info.txId, ExplorerId.DragonGlass);
+    }
+
+    function onOpenHashScan() {
+        invoke('open-transaction-explorer', info.txId, ExplorerId.HashScan);
+    }
+</script>
+
+<dialog bind:this={dialog}>
+    <section>
+        <button on:click={onClose} class="close-dialog"></button>                
+        <h1>{title}</h1>
+        <div>
+            {#if info}                
+                <h2><span class="network">{info.network}</span></h2>
+                {#if info.error}
+                    <div>{info.error}</div>
+                {:else}
+                    <div>{displayEpochString(info.consensus_timestamp)}</div>
+                    <div>{info.name}</div>
+                    <div>{info.result}</div>                    
+                {/if}
+                <div class="lookup">More info on</div>
+                <ul>
+                    <li on:click={onOpenDragonglass}>DragonGlass</li>
+                    <li on:click={onOpenHashScan}>HashScan</li>
+                </ul>
+            {:else}
+                <div>Retrieving current info ...</div>
+            {/if}
+        </div>
+    </section>
+</dialog>
+
+<style>
+    dialog > section {
+        display: grid;
+        grid-template-rows: max-content max-content 1fr;
+        margin: 0;
+        padding: 0;
+        width: min(90vw, 36rem);
+        min-height: 17rem;
+        color: var(--cds-nl-0);
+    }
+    dialog > section > div {
+        padding: 0 3rem 1rem 3rem;
+    }
+    h1 {
+        margin: 0 3rem;
+        padding: 0;
+        font-weight: 600;
+        font-size: 1.25rem;
+    }
+    h2 {
+        margin: 0 0 1rem 0;
+        padding: 0;
+        font-weight: 300;
+        font-size: 1rem;
+        line-height: 1;
+    }
+    button.close-dialog {
+        justify-self: end;        
+        margin: 1rem 1rem 0 0;
+    }
+	.network, i {
+		color: var(--cds-cs-500);
+	}
+    .lookup {
+        margin-top: 1rem;
+    }
+    ul {
+        margin: 0;
+    }
+    li {
+        cursor: pointer;
+    }
+    li:active, li:focus, li:hover {
+        color: var(--cds-cs-500);
+        text-decoration: underline;
+    }
+</style>

--- a/src/app/components/TransfersTable.svelte
+++ b/src/app/components/TransfersTable.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-import { invoke } from "../common/ipc";
-
+    import AccountInfoDialog from "./AccountInfoDialog.svelte";
 
   	export let transfers: { account:string, amount: string }[];
     export let decimals: number = 0;  
+    let accountInfoDialog: AccountInfoDialog;
 
     $: data = transfers.map(t => { 
         const [shard, realm, num] = t.account.split('.');
@@ -29,7 +29,7 @@ import { invoke } from "../common/ipc";
                 evt.preventDefault();
                 const transfer = transfers[index-1];
                 if(transfer) {
-                    await invoke('open-address-explorer',transfer.account);
+                    accountInfoDialog.showDialog(transfer.account);
                 }
             }
         }
@@ -47,6 +47,7 @@ import { invoke } from "../common/ipc";
         <div class="amount"><span class="whole">{whole}</span><span class="fraction">.{fraction}</span></div>
         {/each}
     </div>
+    <AccountInfoDialog bind:this={accountInfoDialog}/>
 </div>
 
 <style>

--- a/src/app/pages/Page06.svelte
+++ b/src/app/pages/Page06.svelte
@@ -7,7 +7,7 @@
 	import DistributionsTable from '../components/DistributionsTable.svelte';
 	import ErrorsTable from '../components/ErrorsTable.svelte';
 	import PagingController from '../components/PagingController.svelte';
-import { PaymentStage } from '../../common/primitives';
+	import { PaymentStage } from '../../common/primitives';
 
 	let selectedTab = 0;
 	let results = null;

--- a/src/common/convert.ts
+++ b/src/common/convert.ts
@@ -1,0 +1,17 @@
+/**
+ * Helper function producing a localized display
+ * date/time string from an epoch date string.
+ *
+ * @param value epoch date string in the form of
+ * <seconds>.<nanos>.
+ *
+ * @returns a human readable localized string
+ * representation of the date.
+ */
+export function displayEpochString(value: string): string {
+	const [secondsAsString, nanosecondsAsString] = value.split('.');
+	const seconds = parseInt(secondsAsString, 10);
+	const nanoseconds = parseInt(nanosecondsAsString, 10);
+	const date = new Date(seconds * 1000 + nanoseconds / 1000000.0);
+	return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+}

--- a/src/common/primitives.ts
+++ b/src/common/primitives.ts
@@ -13,6 +13,20 @@ export enum NetworkId {
 	Test = 2,
 }
 /**
+ * Enumerator identifying the network explorer
+ * to attempt to connect to.
+ */
+export enum ExplorerId {
+	/**
+	 * DragonGlass
+	 */
+	DragonGlass = 1,
+	/**
+	 * HashScan.io
+	 */
+	HashScan = 2,
+}
+/**
  * Enumerator identifying the macro stage an individual
  * payment may be in.  There are three ending stage
  * results: scheduled, completed and failed.

--- a/src/process/client/try-get-transaction-receipt.ts
+++ b/src/process/client/try-get-transaction-receipt.ts
@@ -1,4 +1,3 @@
-
 import { proto } from '@hashgraph/proto';
 import { TransactionReceiptQuery } from '@hashgraph/sdk';
 /**

--- a/src/process/csv.ts
+++ b/src/process/csv.ts
@@ -122,24 +122,24 @@ export async function loadAndParseCsvDistributionFile(filename: string): Promise
 						}
 						columns = Math.max(columns, items.length);
 						const column0 = items[0];
-						if(column0 === null || column0 === undefined || column0.trim() === '') {
+						if (column0 === null || column0 === undefined || column0.trim() === '') {
 							errors.push({
 								line: rows,
 								column: 1,
 								description: `Account Id is missing.`,
 							});
-							return items;							
+							return items;
 						}
-						if(!/^\d+\.\d+\.\d+$/.test(column0)) {
+						if (!/^\d+\.\d+\.\d+$/.test(column0)) {
 							errors.push({
 								line: rows,
 								column: 1,
 								description: `Unable to parse Account ID: ${column0} is not a valid address id.`,
 							});
-							return items;							
+							return items;
 						}
 						let account: AccountId;
-						try {							
+						try {
 							account = AccountId.fromString(column0);
 						} catch (err) {
 							errors.push({

--- a/src/process/ipc.ts
+++ b/src/process/ipc.ts
@@ -12,14 +12,8 @@ import {
 	setTreasuryInformation,
 } from './distribution';
 import { validatePrivateKey } from './keys';
-import {
-	getAppVersion,
-	openAddressExplorer,
-	openScheduledTransactionExplorer,
-	openTransactionExplorer,
-	queryUserForCsvFile,
-	queryUserForOutputFile,
-} from './ui';
+import { getAccountInfo, getScheduleInfo, getTransactionInfo } from './mirror';
+import { getAppVersion, openAccountExplorer, openScheduleExplorer, openTransactionExplorer, queryUserForCsvFile, queryUserForOutputFile } from './ui';
 /**
  * The registry of supported/whitelisted methods executing in the
  * node process thread that can be invoked from the Electron User
@@ -38,9 +32,12 @@ const methods: { [key: string]: (...args: any[]) => Promise<any> } = {
 	'query-user-for-output-file': queryUserForOutputFile,
 	'save-results-output-file': saveDistributionResultsFile,
 	'get-app-version': getAppVersion,
-	'open-address-explorer': openAddressExplorer,
+	'get-transaction-info': getTransactionInfo,
+	'get-account-info': getAccountInfo,
+	'get-schedule-info': getScheduleInfo,
+	'open-account-explorer': openAccountExplorer,
+	'open-schedule-explorer': openScheduleExplorer,
 	'open-transaction-explorer': openTransactionExplorer,
-	'open-scheduled-transaction-explorer': openScheduledTransactionExplorer,
 };
 /**
  * The single IPC entry point used by the Electron User Interface

--- a/src/process/mirror.ts
+++ b/src/process/mirror.ts
@@ -1,0 +1,185 @@
+import { request, Agent } from 'https';
+import { displayEpochString } from '../common/convert';
+import { NetworkId } from '../common/primitives';
+import { getNetworkId } from './distribution';
+/**
+ * A common http agent configured with `keepalive` to true, this attempts
+ * to reduce the I/O burden on the mirror node, increasing the reliability
+ * of connection.
+ */
+const agent = new Agent({ keepAlive: true });
+/**
+ * Retrieves the details of the specified transaction, will wait a period
+ * of time for the mirror node to sync if necessary.
+ *
+ * @param accountId the account id in shard.realm.num format.
+ * @param seconds the transaction starting seconds.
+ * @param nanos the transaction starting nanos.
+ *
+ * @returns an object literal structure representing the details
+ * of the transaction as returned by the remote mirror node.
+ */
+export async function getTransactionInfo(accountId: string, seconds: number, nanos: number, scheduled = false, nonce = 0): Promise<any> {
+	const network = getNetworkId() === NetworkId.Test ? 'Testnet' : 'Mainnet';
+	const txId = { accountId, seconds, nanos, scheduled, nonce };
+	const transactionId = `${accountId}-${seconds.toFixed(0)}-${nanos.toFixed(0).padStart(9, '0')}`;
+	const scheduledFlag = scheduled ? 'true' : 'false';
+	const options = {
+		hostname: getMirrorHostname(),
+		path: `/api/v1/transactions/${transactionId}?nonce=${nonce}&scheduled=${scheduledFlag}`,
+		method: 'GET',
+		agent,
+	};
+	try {
+		const data = await executeRequestWithRetry(options);
+		const parsed = JSON.parse(data.toString('ascii'));
+		const record = parsed.transactions ? parsed.transactions.find((t) => t.transaction_id === transactionId) : null;
+		if (record) {
+			return {
+				txId,
+				...record,
+				network,
+			};
+		} else {
+			return { txId, error: 'Transaction not found.', network };
+		}
+	} catch (err) {
+		const error = err.message || err.toString();
+		return { txId, error, network };
+	}
+}
+/**
+ * Retrieves the details of the specified account from a mirror node,
+ * will wait a period of time for the mirror node to sync if necessary.
+ *
+ * @param accountId the account id in shard.realm.num format.
+ *
+ * @returns an object literal structure representing the details
+ * of the account as returned by the remote mirror node.
+ */
+export async function getAccountInfo(accountId: string): Promise<any> {
+	const network = getNetworkId() === NetworkId.Test ? 'Testnet' : 'Mainnet';
+	const options = {
+		hostname: getMirrorHostname(),
+		path: `/api/v1/balances?account.id=${accountId}`,
+		method: 'GET',
+		agent,
+	};
+	try {
+		const data = await executeRequestWithRetry(options);
+		const parsed = JSON.parse(data.toString('ascii'));
+		const timestamp = parsed.timestamp ? displayEpochString(parsed.timestamp) : null;
+		const record = parsed.balances ? parsed.balances.find((b) => b.account === accountId) : null;
+		if (record) {
+			return {
+				accountId,
+				balance: record.balance,
+				tokens: record.tokens || [],
+				timestamp,
+				network,
+			};
+		} else {
+			return { accountId, error: 'Account information not found.', network, timestamp };
+		}
+	} catch (err) {
+		const error = err.message || err.toString();
+		return { accountId, error, network };
+	}
+}
+/**
+ * Retrieves the details of the specified scheduled transaction from
+ * a mirror node, will wait a period of time for the mirror node to
+ * sync if necessary.
+ *
+ * @param scheduleId the schedule id in shard.realm.num format.
+ *
+ * @returns an object literal structure representing the details
+ * of the schedule as returned by the remote mirror node.
+ */
+export async function getScheduleInfo(scheduleId: string): Promise<any> {
+	const network = getNetworkId() === NetworkId.Test ? 'Testnet' : 'Mainnet';
+	const options = {
+		hostname: getMirrorHostname(),
+		path: `/api/v1/schedules/${scheduleId}`,
+		method: 'GET',
+		agent,
+	};
+	try {
+		const data = await executeRequestWithRetry(options);
+		const parsed = JSON.parse(data.toString('ascii'));
+		const timestamp = parsed.consensus_timestamp ? displayEpochString(parsed.consensus_timestamp) : null;
+		const signingKeys = (parsed.signatures || []).map((s) => s.public_key_prefix).filter((s) => !!s);
+		if (timestamp) {
+			return {
+				scheduleId,
+				createdById: parsed.creator_account_id,
+				payerId: parsed.payer_account_id,
+				deleted: parsed.deleted,
+				executed: parsed.executed_timestamp ? displayEpochString(parsed.executed_timestamp) : null,
+				signingKeys,
+				timestamp,
+				network,
+			};
+		} else {
+			return { scheduleId, error: 'Schedule information not found.', network, timestamp };
+		}
+	} catch (err) {
+		const error = err.message || err.toString();
+		return { scheduleId, error, network };
+	}
+}
+/**
+ * Internal helper function that performs the actual REST API call to
+ * the mirror node.  It assumes input values are 'correct' such that
+ * it will retry the request upon any failure for set number of tries
+ * before raising an error.
+ *
+ * @param options The http request options of the request.
+ *
+ * @returns A buffer object containing the data returned from the request,
+ * or an error is thrown for non 200 responses.
+ */
+async function executeRequestWithRetry(options): Promise<Buffer> {
+	let code;
+	let data;
+	for (let i = 0; i < 30; i++) {
+		({ code, data } = await executeRequest(options));
+		if (code === 200) {
+			return data;
+		} else if (code === 404) {
+			await new Promise((resolve) => setTimeout(resolve, 7000));
+		}
+	}
+	throw new Error(`Received error code: ${code}`);
+}
+/**
+ * Low level helper function implementing the call to the REST API.
+ *
+ * @param options HTTP options sent in from calling code.
+ *
+ * @returns An object containing the HTTP code returned (typically 200)
+ * and the data from the body of the returned message.
+ */
+function executeRequest(options): Promise<{ code: number; data: Buffer }> {
+	const data = [];
+	return new Promise((resolve, reject) => {
+		const req = request(options, (res) => {
+			res.on('data', (chunk) => {
+				data.push(chunk);
+			});
+			res.on('end', () => resolve({ code: res.statusCode, data: Buffer.concat(data) }));
+		});
+		req.on('error', (e) => reject(e));
+		req.end();
+	});
+}
+/**
+ * Low level helper function returining the proper mirrror node
+ * address based upon the current distribution configuration.
+ *
+ * @returns the hostname of the mirror node to query (either the
+ * testnet or mainnet mirror node hostname).
+ */
+function getMirrorHostname() {
+	return getNetworkId() === NetworkId.Test ? 'testnet.mirrornode.hedera.com' : 'mainnet-public.mirrornode.hedera.com';
+}

--- a/src/process/mirror.ts
+++ b/src/process/mirror.ts
@@ -39,9 +39,10 @@ export async function getTransactionInfo(accountId: string, seconds: number, nan
 				txId,
 				...record,
 				network,
+				raw: parsed,
 			};
 		} else {
-			return { txId, error: 'Transaction not found.', network };
+			return { txId, error: 'Transaction not found.', network, raw: parsed };
 		}
 	} catch (err) {
 		const error = err.message || err.toString();
@@ -77,9 +78,10 @@ export async function getAccountInfo(accountId: string): Promise<any> {
 				tokens: record.tokens || [],
 				timestamp,
 				network,
+				raw: parsed,
 			};
 		} else {
-			return { accountId, error: 'Account information not found.', network, timestamp };
+			return { accountId, error: 'Account information not found.', network, timestamp, raw: parsed };
 		}
 	} catch (err) {
 		const error = err.message || err.toString();
@@ -119,9 +121,10 @@ export async function getScheduleInfo(scheduleId: string): Promise<any> {
 				signingKeys,
 				timestamp,
 				network,
+				raw: parsed,
 			};
 		} else {
-			return { scheduleId, error: 'Schedule information not found.', network, timestamp };
+			return { scheduleId, error: 'Schedule information not found.', network, timestamp, raw: parsed };
 		}
 	} catch (err) {
 		const error = err.message || err.toString();


### PR DESCRIPTION
Fixes #39  Updated user interface to swap
Kabuto explorer links to DragonGlass &
HashScan explorer links.

This introduces an additional dependence
on a mirror node for the target network.
The algorithms first query the mirror node
for basic information to display to the user
which additionally help formulate links to
the various explorers.

Not all explorers support all types of entitites
and transactions created by this application.